### PR TITLE
use peerDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,16 @@
     "type": "git",
     "url": "https://github.com/magalhas/backbone-react-component.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "backbone": "^1.1.2",
-    "underscore": "^1.6.0",
     "react": "^0.9.0"
   },
+  "dependencies": {
+    "underscore": "^1.6.0"
+  },
   "devDependencies": {
+    "backbone": "^1.1.2",
+    "react": "^0.9.0",
     "grunt-contrib-uglify": "^0.3.2",
     "grunt": "^0.4.2",
     "grunt-contrib-jasmine": "^0.6.1",


### PR DESCRIPTION
hi!

[peerDependencies](http://blog.nodejs.org/2013/02/07/peer-dependencies/) are great for plugins that extend functionality of other libraries. without peerDeps, it's very likely to have multiple different `backbone` and `react` instances, anytime except for when the package using `backbone-react-component` has the _exact_ same `backbone` and `react` versions, which is not so good.

cheers :)
