### PR TITLE
Update React to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "backbone": "^1.1.2"
   },
   "dependencies": {
+    "react": "^0.11.0",
     "underscore": "^1.6.0"
   },
   "devDependencies": {
     "backbone": "^1.1.2",
-    "react": "^0.11.0",
     "grunt-contrib-uglify": "^0.3.2",
     "grunt": "^0.4.2",
     "grunt-contrib-jasmine": "^0.6.1",


### PR DESCRIPTION
Remove react peerDependency as it creates an annoying npm error when upgrading to the latest react (`0.11.0`). See this[ issue](https://github.com/npm/npm/issues/5080#issuecomment-40545599) about peerDependencies and how they are not that great :cry:.
Updated react devDependency to `^0.11.0`
