### PR TITLE
Changing `renderComponent` to `render` in example

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -25,7 +25,7 @@
 //       }
 //     });
 //     var model = new Backbone.Model({foo: 'bar'});
-//     React.renderComponent(<MyComponent model={model} />, document.body);
+//     React.render(<MyComponent model={model} />, document.body);
 
 (function (root, factory) {
   // Universal module definition


### PR DESCRIPTION
`React.renderComponent` is now deprecated, modifying the example to use `React.render`
