### PR TITLE
check component is mounted when updating props

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ var ParentComponent = React.createClass({
 
     // Remount child as a new root component.
     React.render(
-      <ChildComponent />,
+      <ChildComponent collection={collection} />,
       this.refs.childContainer.getDOMNode()
     );
   },

--- a/lib/component.js
+++ b/lib/component.js
@@ -247,7 +247,7 @@
         this.nextProps = _.extend(this.nextProps || {}, props);
         _.defer(_.bind(function () {
           if (this.nextProps) {
-            if (this.component) {
+            if (this.component && this.component.isMounted()) {
               this.component.setProps(this.nextProps);
             }
             delete this.nextProps;


### PR DESCRIPTION
Hello, @magalhas!

My use case which this PR fixes:

```coffeescript
    @setState saving: yes, =>
      workUnit.save(attrs, opts)
        .done =>
          @setState saving: false, =>
            workUnit.collection.add(workUnit) if isNew
            @hide()
        .fail =>
          @setState saving: false
          @showError(t('cannot_save', tOpts))
```

I use modal dialog to create a model. After save I add new model to collection and then hide a modal dialog.
As I guess adding model to a collection triggers deferred `setProps` and when it's called component is already unmounted. It causes `Uncaught Error: Invariant Violation: replaceProps(...): Can only update a mounted component.`