### PR TITLE
React Native support for backbone-react-component

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -32,7 +32,13 @@
   if (typeof define === 'function' && define.amd) {
     define(['react', 'backbone', 'underscore'], factory);
   } else if (typeof module !== 'undefined' && module.exports) {
-    module.exports = factory(require('react'), require('backbone'), require('underscore'));
+    var react = null;
+    try {
+      react = require('react');
+    } catch (error) {
+      react = require('React'); // React Native
+    }
+    module.exports = factory(react, require('backbone'), require('underscore'));
   } else {
     factory(root.React, root.Backbone, root._);
   }

--- a/lib/component.js
+++ b/lib/component.js
@@ -33,16 +33,18 @@
     define(['react', 'backbone', 'underscore'], factory);
   } else if (typeof module !== 'undefined' && module.exports) {
     var react = null;
+    var isReactNative = false;
     try {
       react = require('react');
     } catch (error) {
       react = require('React'); // React Native
+      isReactNative = true;
     }
-    module.exports = factory(react, require('backbone'), require('underscore'));
+    module.exports = factory(isReactNative, react, require('backbone'), require('underscore'));
   } else {
     factory(root.React, root.Backbone, root._);
   }
-}(this, function (React, Backbone, _) {
+}(this, function (isReactNative, React, Backbone, _) {
   'use strict';
   if (!Backbone.React) {
     Backbone.React = {};
@@ -76,11 +78,15 @@
     },
     // Sets `this.el` and `this.$el` when the component mounts.
     componentDidMount: function () {
-      this.setElement(React.findDOMNode(this));
+      if (isReactNative === false) {
+        this.setElement(React.findDOMNode(this));
+      }
     },
     // Sets `this.el` and `this.$el` when the component updates.
     componentDidUpdate: function () {
-      this.setElement(React.findDOMNode(this));
+      if (isReactNative === false) {
+        this.setElement(React.findDOMNode(this));
+      }
     },
     // When the component gets the initial state, instance a `Wrapper` to take
     // care of models and collections binding with `this.state`.


### PR DESCRIPTION
these changes seem to be the minimal amount needed to make backbone-react-component usable in react-native. it's been really useful to me and i figure others will find backbone-react-component handy in their react-native projects as well.