### PR TITLE
Update React version to 15.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   "main": "lib/component.js",
   "dependencies": {
     "backbone": "^1.2.0",
-    "react": "^0.14.0",
+    "react": "^15.3.0",
     "underscore": "^1.8.3"
   },
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "peerDependencies": {
     "backbone": "^1.2.3",
-    "react": "^0.14.0"
+    "react": "^15.3.0"
   },
   "dependencies": {
     "underscore": "^1.8.3"
@@ -29,8 +29,8 @@
     "grunt-docco": "^0.4.0",
     "grunt-gh-pages": "^0.10.0",
     "jquery": "^2.1.4",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^15.3.0",
+    "react-dom": "^15.3.0"
   },
   "scripts": {
     "test": "grunt test",


### PR DESCRIPTION
At the moment it is not possible to use latest version of react and react-dom in projects together with backbone-react-component due to older versions declared in it.

Tests passed ok on my local environment, but please let me know if there are any pitfalls and there is no chance for upgrade.
