### PR TITLE
Fix for React 15.5+ (missing React.PropTypes)

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -30,13 +30,13 @@
 (function (root, factory) {
   // Universal module definition
   if (typeof define === 'function' && define.amd) {
-    define(['react', 'react-dom', 'backbone', 'underscore'], factory);
+    define(['react', 'react-dom', 'backbone', 'underscore', 'prop-types'], factory);
   } else if (typeof module !== 'undefined' && module.exports) {
-    module.exports = factory(require('react'), require('react-dom'), require('backbone'), require('underscore'));
+    module.exports = factory(require('react'), require('react-dom'), require('backbone'), require('underscore'), require('prop-types'));
   } else {
-    factory(root.React, root.ReactDOM, root.Backbone, root._);
+    factory(root.React, root.ReactDOM, root.Backbone, root._, root.PropTypes);
   }
-}(this, function (React, ReactDOM, Backbone, _) {
+}(this, function (React, ReactDOM, Backbone, _, PropTypes) {
   'use strict';
   if (!Backbone.React) {
     Backbone.React = {};
@@ -49,16 +49,16 @@
     // Types of the context passed to child components. Only
     // `hasParentBackboneMixin` is required all of the others are optional.
     childContextTypes: {
-      hasParentBackboneMixin: React.PropTypes.bool.isRequired,
-      parentModel: React.PropTypes.any,
-      parentCollection: React.PropTypes.any
+      hasParentBackboneMixin: PropTypes.bool.isRequired,
+      parentModel: PropTypes.any,
+      parentCollection: PropTypes.any
     },
     // Types of the context received from the parent component. All of them are
     // optional.
     contextTypes: {
-      hasParentBackboneMixin: React.PropTypes.bool,
-      parentModel: React.PropTypes.any,
-      parentCollection: React.PropTypes.any
+      hasParentBackboneMixin: PropTypes.bool,
+      parentModel: PropTypes.any,
+      parentCollection: PropTypes.any
     },
     // Passes data to our child components.
     getChildContext: function () {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react": "^15.3.0"
   },
   "dependencies": {
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "prop-types": "^15.6.2"
   },
   "devDependencies": {
     "backbone": "^1.2.3",


### PR DESCRIPTION
Imported the new `prop-type` package and used it in place of `React.PropTypes` within `/lib/components.js`
See https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactproptypes 